### PR TITLE
Add telegram alert functionality

### DIFF
--- a/impf/alert.py
+++ b/impf/alert.py
@@ -6,6 +6,8 @@ from typing import Union
 import settings
 from impf.constructors import zulip_client, zulip_send_payload, zulip_read_payload, get_command
 
+import requests
+
 logger = logging.getLogger(__name__)
 p = re.compile("sms:\d{3}-?\d{3}")
 
@@ -36,6 +38,8 @@ def send_alert(message: str) -> None:
         except: pass
     if settings.ZULIP_ENABLED:
         zulip_send(message)
+    if settings.TELEGRAM_ENABLED:
+        telegram_send(message)
 
 
 def zulip_send(message: str) -> None:
@@ -57,3 +61,11 @@ def zulip_read() -> str:
     for message in r.get('messages'):
         if sms_code(message.get('content')):
             return sms_code(message.get('content'))
+
+def telegram_send(message: str) -> None:
+    bot_token = settings.TELEGRAM_BOT_TOKEN
+    bot_chatID = settings.TELEGRAM_BOT_CHATID
+
+    send_text = 'https://api.telegram.org/bot' + bot_token + '/sendMessage?chat_id=' + bot_chatID + '&parse_mode=Markdown&text=' + message
+
+    response = requests.get(send_text)

--- a/main.py
+++ b/main.py
@@ -21,6 +21,7 @@ def print_config() -> None:
     print('[x] Alerting Methods')
     if settings.COMMAND_ENABLED: print('- Custom Command ✓')
     if settings.ZULIP_ENABLED: print('- Zulip ✓')
+    if settings.TELEGRAM_ENABLED: print('- Telegram ✓')
 
 def print_version() -> None:
     from impf import __version__ as v

--- a/settings.sample.py
+++ b/settings.sample.py
@@ -107,6 +107,11 @@ ZULIP_TARGET: str = 'hunter'
 ZULIP_TOPIC: str = 'General'
 
 
+# Telegram (https://core.telegram.org/)
+TELEGRAM_ENABLED: bool = False
+TELEGRAM_BOT_TOKEN: str = '1111111111:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+TELEGRAM_BOT_CHATID: str = '111111111'
+
 
 # > Logging Setup
 # ----------------------


### PR DESCRIPTION
Hi,

thank you for the great work on this bot.
The telegram bot API is very simple, so I added a telegram notification functionality (can't read back codes, only sends alerts).
I tested it using the "--alert" flag and it seems to work.

I also added the settings entries. The bot must first be created in the Telegram app using the BotFather. An explanation of the process is given e.g. here: https://www.techthoughts.info/how-to-create-a-telegram-bot-and-send-messages-via-api/

Marius