### PR TITLE
Make the wait time when using RESCAN_APPOINTMENT configurable

### DIFF
--- a/impf/browser.py
+++ b/impf/browser.py
@@ -433,7 +433,8 @@ class Browser:
         Impfterminen mit vorhandenem Vermittlungscode zu prüfen """
         appointments = self.search_appointments()
         if settings.RESCAN_APPOINTMENT and not appointments:
-            self.logger.info(f'RESCAN_APPOINTMENT is enabled - automatically rechecking in {settings.WAIT_RESCAN_APPOINTMENTS}s...')
+            self.logger.info(f'RESCAN_APPOINTMENT is enabled - automatically rechecking in '
+                             f'{settings.WAIT_RESCAN_APPOINTMENTS // 60}min...')
             while not appointments:
                 sleep(settings.WAIT_RESCAN_APPOINTMENTS)
                 self.logger.info('Rechecking for new appointments')

--- a/impf/browser.py
+++ b/impf/browser.py
@@ -433,9 +433,9 @@ class Browser:
         Impfterminen mit vorhandenem Vermittlungscode zu prüfen """
         appointments = self.search_appointments()
         if settings.RESCAN_APPOINTMENT and not appointments:
-            self.logger.info('RESCAN_APPOINTMENT is enabled - automatically rechecking in 10m...')
+            self.logger.info(f'RESCAN_APPOINTMENT is enabled - automatically rechecking in {settings.WAIT_RESCAN_APPOINTMENTS}s...')
             while not appointments:
-                sleep(45)  # 15 seconds overhead
+                sleep(settings.WAIT_RESCAN_APPOINTMENTS)
                 self.logger.info('Rechecking for new appointments')
                 self.rescan_appointments()
                 appointments = self.search_appointments()

--- a/settings.sample.py
+++ b/settings.sample.py
@@ -59,6 +59,9 @@ WAIT_SHADOW_BAN: int = 60*12  # 12 Min
 # Seconds to wait time before attempting another API call. Only relevant
 # if using instant codes or BOOKING_ENABLED
 WAIT_API_CALLS: int = 60*1  # 1 Min
+# Seconds to wait before rechecking available appointments. Only relevant
+# if RESCAN_APPOINTMENT is set to True
+WAIT_RESCAN_APPOINTMENTS: int = 45
 
 # > Basic Features
 # ----------------------

--- a/settings.sample.py
+++ b/settings.sample.py
@@ -61,7 +61,7 @@ WAIT_SHADOW_BAN: int = 60*12  # 12 Min
 WAIT_API_CALLS: int = 60*1  # 1 Min
 # Seconds to wait before rechecking available appointments. Only relevant
 # if RESCAN_APPOINTMENT is set to True
-WAIT_RESCAN_APPOINTMENTS: int = 45
+WAIT_RESCAN_APPOINTMENTS: int = 60*2.5  # 2,5 Min
 
 # > Basic Features
 # ----------------------


### PR DESCRIPTION
It seems to me that rechecking every minute/45s is unnecessary as appointments are reserved for 10 minutes (at least it's thus stated). Therefore I'd suggest to increase the wait time to 300 (?) seconds. This should also reduce the risk of a shadow ban.

To be flexible, I just made the wait time configurable.

I also could change the logging to tell the minutes instead of seconds, but that would not make much sense with a default of 45 seconds.