### PR TITLE
It's sufficicent to only click once in location_page

### DIFF
--- a/impf/browser.py
+++ b/impf/browser.py
@@ -184,7 +184,7 @@ class Browser:
 
         # Small Mouse Wiggle heh
         action = ActionChains(self.driver)
-        action.move_to_element(element).click().perform()
+        action.move_to_element(element).perform()
         action.move_by_offset(40, 20).perform()
         element.click()
         action.move_by_offset(10, 5).perform()

--- a/impf/browser.py
+++ b/impf/browser.py
@@ -186,7 +186,8 @@ class Browser:
         action = ActionChains(self.driver)
         action.move_to_element(element).perform()
         action.move_by_offset(40, 20).perform()
-        element.click()
+        sleep(.25)
+        action.move_to_element(element).click().perform()
         action.move_by_offset(10, 5).perform()
 
         # Ensure vacancy has fully loaded before proceeding


### PR DESCRIPTION
While wiggling the mouse, there was one click() too many that was probably a leftover from some refactoring