### PR TITLE
Fix some problems with the docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,8 @@ RUN DEBIAN_FRONTEND=noninteractive \
 WORKDIR /app
 
 # Copy project files in directory
-COPY . .
+COPY requirements.txt main.py ./
+COPY impf/ ./impf/
 
 RUN pip3 install -r /app/requirements.txt
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,10 +10,8 @@ RUN DEBIAN_FRONTEND=noninteractive \
     xorg vnc4server autocutsel lxde-core novnc python-websockify \
     libffi-dev musl-dev libssl-dev python3-dev gcc \
     python3 python3-pip \
+    chromium-driver=90.0.4430.212-1~deb10u1 \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-RUN wget -O /tmp/chromedriver.zip https://chromedriver.storage.googleapis.com/90.0.4430.24/chromedriver_linux64.zip \
-    && unzip /tmp/chromedriver.zip -d /usr/local/bin/
 
 WORKDIR /app
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,6 +11,7 @@ services:
         ports:
             - 5901:5901
             - 6901:6901
+        tmpfs: /tmp
         environment:
             - VNC_PASSWORD=CHANGEME
             - TZ=Europe/Berlin

--- a/docker/xstartup.sh
+++ b/docker/xstartup.sh
@@ -6,5 +6,6 @@ xsetroot -solid grey
 #x-window-manager &
 # Fix to make GNOME work
 export XKL_XMODMAP_DISABLE=1
+export LC_CTYPE=C.UTF-8 #Fix unicode output in uxterm
 /etc/X11/Xsession  &
 x-terminal-emulator -e "python3 /app/main.py"


### PR DESCRIPTION
Hey there,
I decided to upstream some of the changes I made!
This PR fixes several problems with the docker build/image provided:

- noVNC seems to place a lock file into `/tmp`. Before this PR, this directory was never cleaned up and a subsequent restart of the container would make noVNC fail. Making `/tmp` a tmpfs mount fixes this
- Google does not provide a build of `chromedriver` for armhf architectures (anymore?), which makes the bot fail on devices such as, say, a Raspberry Pi. Replacing the sideloaded binary with the debian provided one omits this problem
- Leave unnecessary files out of the container, such as `tests/`, `.git/`,...
- Fix unicode output of the terminal emulator in the container, so words like "Baden-Württemberg" are displayed correctly. The X-Server now uses `uxterm` by default.

Thank you for all your hard work!