### PR TITLE
Raise Exception after failure to recover from shadow ban; fixes issue…

### DIFF
--- a/impf/exceptions.py
+++ b/impf/exceptions.py
@@ -35,3 +35,7 @@ class AlertError(Exception):
 
     def __str__(self):
         return f'[{self.code}] {self.message}'
+
+
+class WorkflowException(Exception):
+    pass

--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ from impf import __version__ as v
 from impf.alert import send_alert
 from impf.api import API
 from impf.browser import Browser
+from impf.exceptions import WorkflowException
 
 logger = logging.getLogger(__name__)
 b = None  # helper variable for keeping browser open
@@ -92,7 +93,12 @@ def impf_me(location: dict):
             x.reinit(**location)
 
     # Continue with normal loop
-    x.control_main()
+    try:
+        x.control_main()
+    except WorkflowException as e:
+        # Something unexpected happened, we'll continue with the next loop
+        logger.info(e)
+        pass
 
     logger.info(f'Waiting until {(datetime.now() + timedelta(seconds=settings.WAIT_LOCATIONS)).strftime("%H:%M:%S")} '
                 f'before checking the next location')


### PR DESCRIPTION
…s with continuing broken workflows

This morning I had an issue that recovering from shadow ban failed and then the (now broken) workflow tried to continue resulting in a endless loop of failure.
This change will go back to the main loop and just starts from anew.