### PR TITLE
change RESCAN_APPOINTMENT to counter

### DIFF
--- a/impf/browser.py
+++ b/impf/browser.py
@@ -373,7 +373,7 @@ class Browser:
             if self.driver.find_element_by_xpath('//span[@class="its-slot-pair-search-no-results"]') \
                     or self.driver.find_element_by_xpath(
                     '//span[contains(@class, "text-pre-wrap") and contains(text(), "Fehler")]'):
-                self.logger.info('Vermittlungscode ok, but not free vaccination slots')
+                self.logger.info('Vermittlungscode ok, but no free vaccination slots')
                 return False
         except NoSuchElementException:
             pass
@@ -512,19 +512,21 @@ class Browser:
         Impfterminen mit vorhandenem Vermittlungscode zu prüfen """
 
         appointments = self.search_appointments()
-        if settings.RESCAN_APPOINTMENT and not appointments:
-            self.logger.info(f'RESCAN_APPOINTMENT is enabled - automatically rechecking in '
+        counter = 0
+        while counter < settings.RESCAN_APPOINTMENT and not appointments:
+            self.logger.info(f'automatically rechecking in '
                              f'{settings.WAIT_RESCAN_APPOINTMENTS // 60}min...')
-            while not appointments:
-                sleep(settings.WAIT_RESCAN_APPOINTMENTS)
-                self.logger.info('Rechecking for new appointments')
-                appointments = self.search_appointments()
+
+            sleep(settings.WAIT_RESCAN_APPOINTMENTS)
+            counter = counter + 1
+            self.logger.info(f'Rechecking for new appointments ({counter}/{settings.RESCAN_APPOINTMENT} times)')
+            appointments = self.search_appointments()
 
         if appointments:
             self.alert_appointment()
             sleep(600)
             exit()
-        if settings.RESCAN_APPOINTMENT: return self.control_appointment()
+
         # Rescanning for appointments not enabled
         self.logger.info('No appointments available right now :(')
 

--- a/impf/browser.py
+++ b/impf/browser.py
@@ -513,13 +513,13 @@ class Browser:
 
         appointments = self.search_appointments()
         counter = 0
-        while counter < settings.RESCAN_APPOINTMENT and not appointments:
+        while (settings.RESCAN_APPOINTMENT == 0 or counter < settings.RESCAN_APPOINTMENT) and not appointments:
             self.logger.info(f'automatically rechecking in '
                              f'{settings.WAIT_RESCAN_APPOINTMENTS // 60}min...')
 
             sleep(settings.WAIT_RESCAN_APPOINTMENTS)
             counter = counter + 1
-            self.logger.info(f'Rechecking for new appointments ({counter}/{settings.RESCAN_APPOINTMENT} times)')
+            self.logger.info(f'Rechecking for new appointments ({counter}/{"infinite" if settings.RESCAN_APPOINTMENT == 0 else settings.RESCAN_APPOINTMENT} times)')
             appointments = self.search_appointments()
 
         if appointments:

--- a/settings.sample.py
+++ b/settings.sample.py
@@ -60,7 +60,7 @@ WAIT_SHADOW_BAN: int = 60*12  # 12 Min
 # Only relevant if using instant codes or BOOKING_ENABLED
 WAIT_API_CALLS: int = 60*1  # 1 Min
 # Seconds to wait before rechecking available appointments.
-# Only relevant if RESCAN_APPOINTMENT is > 0
+# Only relevant if RESCAN_APPOINTMENT is > -1
 WAIT_RESCAN_APPOINTMENTS: int = 60*2  # 2 Min
 
 
@@ -76,7 +76,8 @@ AVOID_SHADOW_BAN: bool = True
 # are available once we have passed the *Vermittlungscode* and are in the Online Booking screen.
 # This is done by clicking "Check for new appointments" after the 10m reservation time runs out
 # This prevents the bot from checking only one center over and over again.
-# If set to 0, rescan is disabled.
+# If set to 0, the bot will infinitely rescan.
+# If set to -1, the rescan feature is disabled.
 RESCAN_APPOINTMENT: int = 10
 # Pause bot during night times (2300-0600) since no new appointments are created anyways during
 # that time period. Can help reduce shadow bans

--- a/settings.sample.py
+++ b/settings.sample.py
@@ -60,7 +60,7 @@ WAIT_SHADOW_BAN: int = 60*12  # 12 Min
 # Only relevant if using instant codes or BOOKING_ENABLED
 WAIT_API_CALLS: int = 60*1  # 1 Min
 # Seconds to wait before rechecking available appointments.
-# Only relevant if RESCAN_APPOINTMENT is set to True
+# Only relevant if RESCAN_APPOINTMENT is > 0
 WAIT_RESCAN_APPOINTMENTS: int = 60*2  # 2 Min
 
 
@@ -72,13 +72,12 @@ KEEP_BROWSER: bool = True
 # Checks if the backend is returning error `429` (Too Many Requests) and then sleeps for WAIT_SHADOW_BAN
 # seconds before sending the last request again.
 AVOID_SHADOW_BAN: bool = True
-# Controls whether or not the bot should simply keep on rechecking if new appointments
+# Controls how often the bot should simply keep on rechecking if new appointments
 # are available once we have passed the *Vermittlungscode* and are in the Online Booking screen.
 # This is done by clicking "Check for new appointments" after the 10m reservation time runs out
-# This can be very useful if you only want to check for one center; however it might also result
-# in an undesired behavior; if CONCURRENT_ENABLED is not used the bot will evidently only keep on
-# checking only one center over and over again.
-RESCAN_APPOINTMENT: bool = True
+# This prevents the bot from checking only one center over and over again.
+# If set to 0, rescan is disabled.
+RESCAN_APPOINTMENT: int = 10
 # Pause bot during night times (2300-0600) since no new appointments are created anyways during
 # that time period. Can help reduce shadow bans
 SLEEP_NIGHT: bool = True


### PR DESCRIPTION
Hi,

first of all, thank you very much for your effort. This bot has been really helpful, I appreciate your work.

I ran into the issue you described in the settings file with `CONCURRENT_ENABLED` set to false and only having a Vermittlungscode for one out of multiple centers. I therefore changed the `RESCAN_APPOINTMENT` from bool to int so people can specify how often the bot checks for new appointments before moving on to the next location. Infinite scans can still be allowed by setting the int to `0`, `-1` disables the rescan feature.

This might not be great for backwards compatibility, but I also found it unnecessary to have a bool AND an int. Please let me know in case you want me to change that.

I just thought it might also be interesting for other people. If you don't want the feature or some different behaviour, that's also fine by me ^^