### PR TITLE
Add option to set upper limit of time spent in waiting room

### DIFF
--- a/impf/browser.py
+++ b/impf/browser.py
@@ -18,6 +18,7 @@ import logging
 from impf.api import API
 from impf.constructors import browser_options, format_appointments
 from impf.decorators import shadow_ban, control_errors
+from impf.exceptions import ImpfbotTimeoutError
 
 logger = logging.getLogger(__name__)
 
@@ -195,8 +196,15 @@ class Browser:
 
     def waiting_room(self):
         if not self.in_waiting_room: return
-        self.logger.info('Taking a seat in the waiting room (very german)')
-        while self.in_waiting_room: sleep(5)
+        self.logger.info('Taking a seat in the waiting room (very German)')
+        time_spent_in_waiting_room = 0
+        while self.in_waiting_room:
+            if time_spent_in_waiting_room > settings.WAIT_WAITING_ROOM:
+                raise ImpfbotTimeoutError(f'Maximum time in waiting room ({settings.WAIT_WAITING_ROOM} s) exceeded')
+            sleep_time = 5
+            sleep(sleep_time)
+            time_spent_in_waiting_room += sleep_time
+
         self.logger.info('No longer in waiting room!')
 
     @shadow_ban

--- a/impf/decorators.py
+++ b/impf/decorators.py
@@ -6,7 +6,7 @@ from requests import Timeout, ConnectionError
 from selenium.common.exceptions import StaleElementReferenceException, WebDriverException
 
 import settings
-from impf.exceptions import AdvancedSessionCache, AlertError
+from impf.exceptions import AdvancedSessionCache, AlertError, ImpfbotTimeoutError
 
 logger = logging.getLogger(__name__)
 
@@ -76,6 +76,8 @@ def control_errors(f):
                               'ability to interact before attempting to revover automatically...')
             sleep(120)
             return self.control_assert()
+        except ImpfbotTimeoutError as e:
+            self.logger.info(f'ImpfbotTimeoutError: {str(e)}')
         except SystemExit:
             self.logger.warning('Exiting...')
         except:

--- a/impf/exceptions.py
+++ b/impf/exceptions.py
@@ -35,3 +35,8 @@ class AlertError(Exception):
 
     def __str__(self):
         return f'[{self.code}] {self.message}'
+
+
+class ImpfbotTimeoutError(Exception):
+    """ Custom timeout of impfbot was triggered """
+    pass

--- a/settings.sample.py
+++ b/settings.sample.py
@@ -62,6 +62,10 @@ WAIT_API_CALLS: int = 60*1  # 1 Min
 # Seconds to wait before rechecking available appointments.
 # Only relevant if RESCAN_APPOINTMENT is set to True
 WAIT_RESCAN_APPOINTMENTS: int = 60*2  # 2 Min
+# Seconds to wait in waiting room before skipping the current location
+# Normally, the waiting room should disappear quickly by itself but in some
+# cases a longer wait in there can happen
+WAIT_WAITING_ROOM: int = 60*10  # 10 Min
 
 
 # > Basic Features


### PR DESCRIPTION
While I understand that you do not consider #60 a bug, I think it would still be a great feature if you were able to set an upper limit for the time spent in the waiting room of one location. I had a situation where the waiting room took much longer than 10 min to go away, and I'd think most users would want to continue to other locations in that case.